### PR TITLE
Set len(ip_list) less than 100

### DIFF
--- a/enumXFF.py
+++ b/enumXFF.py
@@ -30,12 +30,12 @@ def generate_ips(ip_range):
 ip_addresses = generate_ips(args.range)
 
 for ip in tqdm(ip_addresses):
-	ip_list = ("{0}, ".format(ip) * 50)[:-2]
+	ip_list = ("{0}, ".format(ip) * 5)[:-2]
 	x_forwarded_for_header = {"X-Forwarded-For" : ip_list}
 	future = session.head(args.target, headers=x_forwarded_for_header)
 	response = future.result()
 	if response.headers['content-length'] > args.badcl:
 		ip_save_file = open(args.output, "a")
 		ip_save_file.write(args.target + ": " + str(x_forwarded_for_header) + "\n")
-		print "\nAccess granted with {0}".format(ip)
+		print("\nAccess granted with {0}".format(ip))
 		break


### PR DESCRIPTION
Services like Cloudflare don't allow length of any header to be more than 100 chars
When setting number of IPs in ip_list variable to 50 IPs,requests are being dropped

Also print without "()" is generating error for "Python 3.4.3"
